### PR TITLE
Feat: 알림서비스에 외부 브로커 redis 추가

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -18,6 +18,8 @@ server {
     location / {
         proxy_pass http://backend;
 
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
- [x] 누락된 nginx 설정 추가

javascript datasource를 연결하기 위해서는 nginx 설정에서 http header에 http version 1.1과 connection ""(비어있는)을 명시해야한다.